### PR TITLE
Include instructions to enable beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Use [this page from Electron docs](https://electronjs.org/docs/api/accelerator#a
 Same config file `.todoist-linux.json` has other options to configure the app:
 
 * `tray-icon` - tray icon to use. Possible options: `icon.png`, `icon_monochrome.png`
+* `beta` - use beta version of Todoist. Possible options: `true`, `false`
 
 ## Why?
 


### PR DESCRIPTION
This adds instructions to enable the beta to the Additional Configuration section.